### PR TITLE
Revert to last correct implementation

### DIFF
--- a/keras_contrib/layers/advanced_activations.py
+++ b/keras_contrib/layers/advanced_activations.py
@@ -69,10 +69,10 @@ class PELU(Layer):
             pos = K.relu(x) * (K.pattern_broadcast(self.alphas, self.param_broadcast) /
                                K.pattern_broadcast(self.betas, self.param_broadcast))
             neg = (K.pattern_broadcast(self.alphas, self.param_broadcast) *
-                   (K.exp(-K.relu(-x) / K.pattern_broadcast(self.betas, self.param_broadcast)) - 1))
+                   (K.exp(((x - K.abs(x)) * 0.5) / K.pattern_broadcast(self.betas, self.param_broadcast)) - 1))
         else:
             pos = K.relu(x) * self.alphas / self.betas
-            neg = self.alphas * (K.exp(-K.relu(-x) / self.betas) - 1)
+            neg = self.alphas * (K.exp(((x - K.abs(x)) * 0.5) / self.betas) - 1)
         return neg + pos
 
     def get_config(self):


### PR DESCRIPTION
Fixing implementation by changing `K.relu(-x)` to `-K.relu(-x)` caused tests to fail for some reason. Reverting to last correct implementation that doesn't fail tests