### PR TITLE
Fix deconv3d in TF backend (correct kernel transpose)

### DIFF
--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -58,7 +58,7 @@ def deconv3d(x, kernel, output_shape, strides=(1, 1, 1),
     x = _preprocess_conv3d_input(x, dim_ordering)
     output_shape = _preprocess_deconv_output_shape(x, output_shape, dim_ordering)
     kernel = _preprocess_conv3d_kernel(kernel, dim_ordering)
-    kernel = tf.transpose(kernel, (0, 1, 3, 4, 2))
+    kernel = tf.transpose(kernel, (0, 1, 2, 4, 3))
     padding = _preprocess_border_mode(border_mode)
     strides = (1,) + strides + (1,)
 

--- a/tests/keras_contrib/layers/test_convolutional.py
+++ b/tests/keras_contrib/layers/test_convolutional.py
@@ -18,12 +18,12 @@ else:
 
 @keras_test
 def test_deconvolution_3d():
-    nb_samples = 2
-    nb_filter = 2
-    stack_size = 3
-    kernel_dim1 = 10
-    kernel_dim2 = 6
-    kernel_dim3 = 5
+    nb_samples = 6
+    nb_filter = 4
+    stack_size = 2
+    kernel_dim1 = 12
+    kernel_dim2 = 10
+    kernel_dim3 = 8
 
     for batch_size in [None, nb_samples]:
         for border_mode in _convolution_border_modes:
@@ -31,13 +31,13 @@ def test_deconvolution_3d():
                 if border_mode == 'same' and subsample != (1, 1, 1):
                     continue
 
-                dim1 = conv_input_length(kernel_dim1, 3, border_mode, subsample[0])
-                dim2 = conv_input_length(kernel_dim2, 3, border_mode, subsample[1])
+                dim1 = conv_input_length(kernel_dim1, 7, border_mode, subsample[0])
+                dim2 = conv_input_length(kernel_dim2, 5, border_mode, subsample[1])
                 dim3 = conv_input_length(kernel_dim3, 3, border_mode, subsample[2])
                 layer_test(convolutional.Deconvolution3D,
                            kwargs={'nb_filter': nb_filter,
-                                   'kernel_dim1': 3,
-                                   'kernel_dim2': 3,
+                                   'kernel_dim1': 7,
+                                   'kernel_dim2': 5,
                                    'kernel_dim3': 3,
                                    'output_shape': (batch_size, nb_filter, dim1, dim2, dim3),
                                    'border_mode': border_mode,
@@ -48,8 +48,8 @@ def test_deconvolution_3d():
 
                 layer_test(convolutional.Deconvolution3D,
                            kwargs={'nb_filter': nb_filter,
-                                   'kernel_dim1': 3,
-                                   'kernel_dim2': 3,
+                                   'kernel_dim1': 7,
+                                   'kernel_dim2': 5,
                                    'kernel_dim3': 3,
                                    'output_shape': (batch_size, nb_filter, dim1, dim2, dim3),
                                    'border_mode': border_mode,
@@ -63,8 +63,8 @@ def test_deconvolution_3d():
 
                 layer_test(convolutional.Deconvolution3D,
                            kwargs={'nb_filter': nb_filter,
-                                   'kernel_dim1': 3,
-                                   'kernel_dim2': 3,
+                                   'kernel_dim1': 7,
+                                   'kernel_dim2': 5,
                                    'kernel_dim3': 3,
                                    'output_shape': (nb_filter, dim1, dim2, dim3),
                                    'border_mode': border_mode,


### PR DESCRIPTION
The `deconv3d` function in the TensorFlow backend reordered the kernel dimensions in the wrong way. It was supposed to swap the input and output channels, but instead it was mixing the channel dimensions and spatial dimensions.

There's now a better test (for `deconv3d`, I didn't improve the original `deconv2d` test) that detects this problem by using a different filter size in each dimension.

See also @gattia's comments on fchollet/keras#4457.

This is a TensorFlow-specific problem, the Theano `deconv3d` works and worked fine.