### PR TITLE
[WIP] Add FCN DenseNets

### DIFF
--- a/keras_contrib/applications/densenet_fcn.py
+++ b/keras_contrib/applications/densenet_fcn.py
@@ -11,10 +11,9 @@ from __future__ import absolute_import
 from __future__ import division
 
 from keras.models import Model
-from keras.layers.core import Dense, Dropout, Activation, Reshape
+from keras.layers.core import Dropout, Activation, Reshape
 from keras.layers.convolutional import Convolution2D, Deconvolution2D, AtrousConvolution2D, UpSampling2D
 from keras.layers.pooling import AveragePooling2D
-from keras.layers.pooling import GlobalAveragePooling2D
 from keras.layers import Input, merge
 from keras.layers.normalization import BatchNormalization
 from keras.regularizers import l2

--- a/keras_contrib/applications/densenet_fcn.py
+++ b/keras_contrib/applications/densenet_fcn.py
@@ -1,0 +1,408 @@
+# -*- coding: utf-8 -*-
+"""FCN DenseNet Models for Keras.
+
+# Reference
+
+- [The One Hundred Layers Tiramisu: Fully Convolutional DenseNets for Semantic Segmentation](https://arxiv.org/pdf/1611.09326.pdf)
+
+"""
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+from keras.models import Model
+from keras.layers.core import Dense, Dropout, Activation, Reshape
+from keras.layers.convolutional import Convolution2D, Deconvolution2D, AtrousConvolution2D, UpSampling2D
+from keras.layers.pooling import AveragePooling2D
+from keras.layers.pooling import GlobalAveragePooling2D
+from keras.layers import Input, merge
+from keras.layers.normalization import BatchNormalization
+from keras.regularizers import l2
+from keras.engine.topology import get_source_inputs
+from keras.applications.imagenet_utils import _obtain_input_shape
+import keras.backend as K
+
+from keras_contrib.layers.convolutional import SubPixelUpscaling
+
+
+def DenseNetFCN(nb_dense_block=5, growth_rate=12, nb_filter=16, nb_layers_per_block=4,
+                bottleneck=False, reduction=0.0, dropout_rate=0.0, weight_decay=1E-4,
+                include_top=True, weights=None,
+                input_tensor=None, input_shape=None, classes=10,
+                upsampling_conv=128, upsampling_type='upscaling', batchsize=None):
+    """Instantiate the DenseNet FCN architecture,
+        optionally loading weights pre-trained
+        on CIFAR-10. Note that when using TensorFlow,
+        for best performance you should set
+        `image_dim_ordering="tf"` in your Keras config
+        at ~/.keras/keras.json.
+
+        The model and the weights are compatible with both
+        TensorFlow and Theano. The dimension ordering
+        convention used by the model is the one
+        specified in your Keras config file.
+
+        # Arguments
+            nb_dense_block: number of dense blocks to add to end (generally = 3)
+            growth_rate: number of filters to add per dense block
+            nb_filter: initial number of filters. -1 indicates initial
+                number of filters is 2 * growth_rate
+            nb_layers_per_block: number of layers in each dense block.
+                Can be a positive integer or a list.
+                If positive integer, a set number of layers per dense block.
+                If list, nb_layer is used as provided. Note that list size must
+                be (nb_dense_block + 1)
+            bottleneck: flag to add bottleneck blocks in between dense blocks
+            reduction: reduction factor of transition blocks.
+                Note : reduction value is inverted to compute compression.
+            dropout_rate: dropout rate
+            weight_decay: weight decay factor
+            include_top: whether to include the fully-connected
+                layer at the top of the network.
+            weights: one of `None` (random initialization) or
+                "cifar10" (pre-training on CIFAR-10)..
+            input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+                to use as image input for the model.
+            input_shape: optional shape tuple, only to be specified
+                if `include_top` is False (otherwise the input shape
+                has to be `(32, 32, 3)` (with `tf` dim ordering)
+                or `(3, 32, 32)` (with `th` dim ordering).
+                It should have exactly 3 inputs channels,
+                and width and height should be no smaller than 8.
+                E.g. `(200, 200, 3)` would be one valid value.
+            classes: optional number of classes to classify images
+                into, only to be specified if `include_top` is True, and
+                if no `weights` argument is specified.
+            upsampling_conv: number of convolutional layers in upsampling via subpixel convolution
+            upsampling_type: Can be one of 'upsampling', 'deconv', 'atrous' and
+                'subpixel'. Defines type of upsampling algorithm used.
+            batchsize: Fixed batch size. This is a temporary requirement for
+                computation of output shape in the case of Deconvolution2D layers.
+                Parameter will be removed in next iteration of Keras, which infers
+                output shape of deconvolution layers automatically.
+
+        # Returns
+            A Keras model instance.
+        """
+
+    if weights not in {None}:
+        raise ValueError('The `weights` argument should be '
+                         '`None` (random initialization) as no '
+                         'model weights are provided.')
+
+    upsampling_type = upsampling_type.lower()
+
+    if upsampling_type not in ['upsampling', 'deconv', 'atrous', 'subpixel']:
+        raise ValueError('Parameter "upsampling_type" must be one of "upsampling", '
+                         '"deconv", "atrous" or "subpixel".')
+
+    if upsampling_type == 'deconv' and batchsize is None:
+        raise ValueError('If "upsampling_type" is deconvoloution, then a fixed '
+                         'batch size must be provided in batchsize parameter.')
+
+    if input_shape is None:
+        raise ValueError('For fully convolutional models, input shape must be supplied.')
+
+    if type(nb_layers_per_block) is not list and nb_dense_block < 1:
+        raise ValueError('Number of dense layers per block must be greater than 1. Argument '
+                         'value was %d.' % (nb_layers_per_block))
+
+    # Determine proper input shape
+    input_shape = _obtain_input_shape(input_shape,
+                                      default_size=32,
+                                      min_size=16,
+                                      dim_ordering=K.image_dim_ordering(),
+                                      include_top=include_top)
+
+    if input_tensor is None:
+        img_input = Input(shape=input_shape)
+    else:
+        if not K.is_keras_tensor(input_tensor):
+            img_input = Input(tensor=input_tensor, shape=input_shape)
+        else:
+            img_input = input_tensor
+
+    x = __create_fcn_dense_net(classes, img_input, include_top, nb_dense_block,
+                               growth_rate, nb_filter, bottleneck, reduction,
+                               dropout_rate, weight_decay, nb_layers_per_block,
+                               upsampling_conv, upsampling_type, batchsize, input_shape)
+
+    # Ensure that the model takes into account
+    # any potential predecessors of `input_tensor`.
+    if input_tensor is not None:
+        inputs = get_source_inputs(input_tensor)
+    else:
+        inputs = img_input
+    # Create model.
+    model = Model(inputs, x, name='fcn-densenet')
+
+    return model
+
+
+def __conv_block(ip, nb_filter, bottleneck=False, dropout_rate=None, weight_decay=1E-4):
+    ''' Apply BatchNorm, Relu, 3x3 Conv2D, optional bottleneck block and dropout
+
+    Args:
+        ip: Input keras tensor
+        nb_filter: number of filters
+        bottleneck: add bottleneck block
+        dropout_rate: dropout rate
+        weight_decay: weight decay factor
+
+    Returns: keras tensor with batch_norm, relu and convolution2d added (optional bottleneck)
+    '''
+
+    concat_axis = 1 if K.image_dim_ordering() == "th" else -1
+
+    x = BatchNormalization(mode=0, axis=concat_axis, gamma_regularizer=l2(weight_decay),
+                           beta_regularizer=l2(weight_decay))(ip)
+    x = Activation('relu')(x)
+
+    if bottleneck:
+        inter_channel = nb_filter * 4  # Obtained from https://github.com/liuzhuang13/DenseNet/blob/master/densenet.lua
+
+        x = Convolution2D(inter_channel, 1, 1, init='he_uniform', border_mode='same', bias=False,
+                          W_regularizer=l2(weight_decay))(x)
+
+        if dropout_rate:
+            x = Dropout(dropout_rate)(x)
+
+        x = BatchNormalization(mode=0, axis=concat_axis, gamma_regularizer=l2(weight_decay),
+                               beta_regularizer=l2(weight_decay))(x)
+        x = Activation('relu')(x)
+
+    x = Convolution2D(nb_filter, 3, 3, init="he_uniform", border_mode="same", bias=False,
+                      W_regularizer=l2(weight_decay))(x)
+    if dropout_rate:
+        x = Dropout(dropout_rate)(x)
+
+    return x
+
+
+def __transition_down_block(ip, nb_filter, compression=1.0, dropout_rate=None, weight_decay=1E-4):
+    ''' Apply BatchNorm, Relu 1x1, Conv2D, optional compression, dropout and Maxpooling2D
+
+    Args:
+        ip: keras tensor
+        nb_filter: number of filters
+        dropout_rate: dropout rate
+        weight_decay: weight decay factor
+
+    Returns: keras tensor, after applying batch_norm, relu-conv, dropout, maxpool
+    '''
+
+    concat_axis = 1 if K.image_dim_ordering() == "th" else -1
+
+    x = BatchNormalization(mode=0, axis=concat_axis, gamma_regularizer=l2(weight_decay),
+                           beta_regularizer=l2(weight_decay))(ip)
+    x = Activation('relu')(x)
+    x = Convolution2D(int(nb_filter * compression), 1, 1, init="he_uniform", border_mode="same", bias=False,
+                      W_regularizer=l2(weight_decay))(x)
+    if dropout_rate:
+        x = Dropout(dropout_rate)(x)
+    x = AveragePooling2D((2, 2), strides=(2, 2))(x)
+
+    return x
+
+
+def __dense_block(x, nb_layers, nb_filter, growth_rate, bottleneck=False, dropout_rate=None, weight_decay=1E-4):
+    ''' Build a dense_block where the output of each conv_block is fed to subsequent ones
+
+    Args:
+        x: keras tensor
+        nb_layers: the number of layers of __conv_block to append to the model.
+        nb_filter: number of filters
+        growth_rate: growth rate
+        bottleneck: bottleneck block
+        dropout_rate: dropout rate
+        weight_decay: weight decay factor
+
+    Returns: keras tensor with nb_layers of __conv_block appended
+    '''
+
+    concat_axis = 1 if K.image_dim_ordering() == "th" else -1
+
+    x_list = [x]
+
+    for i in range(nb_layers):
+        x = __conv_block(x, growth_rate, bottleneck, dropout_rate, weight_decay)
+        x_list.append(x)
+        x = merge(x_list, mode='concat', concat_axis=concat_axis)
+        nb_filter += growth_rate
+
+    return x, nb_filter
+
+
+def __transition_up_block(ip, nb_filters, type='upsampling', output_shape=None, weight_decay=1E-4):
+    ''' SubpixelConvolutional Upscaling (factor = 2)
+
+    Args:
+        ip: keras tensor
+        nb_filters: number of layers
+        type: can be 'upsampling', 'subpixel', 'deconv', or 'atrous'. Determines type of upsampling performed
+        output_shape: required if type = 'deconv'. Output shape of tensor
+        weight_decay: weight decay factor
+
+    Returns: keras tensor, after applying batch_norm, relu-conv, dropout, maxpool
+    '''
+
+    if type == 'upsampling':
+        x = UpSampling2D()(ip)
+    elif type == 'subpixel':
+        x = Convolution2D(nb_filters, 3, 3, activation="relu", border_mode='same', W_regularizer=l2(weight_decay),
+                          bias=False)(ip)
+        x = SubPixelUpscaling(r=2, channels=int(nb_filters // 4))(x)
+        x = Convolution2D(nb_filters, 3, 3, activation="relu", border_mode='same', W_regularizer=l2(weight_decay),
+                          bias=False)(x)
+    elif type == 'atrous':
+        # waiting on https://github.com/fchollet/keras/issues/4018
+        x = AtrousConvolution2D(nb_filters, 3, 3, activation="relu", W_regularizer=l2(weight_decay),
+                                bias=False, atrous_rate=(2, 2))(ip)
+    else:
+        x = Deconvolution2D(nb_filters, 3, 3, output_shape, activation='relu', border_mode='same',
+                            subsample=(2, 2))(ip)
+
+    return x
+
+
+def __create_fcn_dense_net(nb_classes, img_input, include_top, nb_dense_block=5, growth_rate=12,
+                           nb_filter=-1, bottleneck=False, reduction=0.0, dropout_rate=None, weight_decay=1E-4,
+                           nb_layers_per_block=4, upsampling_conv=128, upsampling_type='upsampling', batchsize=None,
+                           input_shape=None):
+    ''' Build the DenseNet model
+
+    Args:
+        nb_classes: number of classes
+        img_input: tuple of shape (channels, rows, columns) or (rows, columns, channels)
+        include_top: flag to include the final Dense layer
+        nb_dense_block: number of dense blocks to add to end (generally = 3)
+        growth_rate: number of filters to add per dense block
+        nb_filter: initial number of filters. Default -1 indicates initial number of filters is 2 * growth_rate
+        bottleneck: add bottleneck blocks
+        reduction: reduction factor of transition blocks. Note : reduction value is inverted to compute compression
+        dropout_rate: dropout rate
+        weight_decay: weight decay
+        nb_layers_per_block: number of layers in each dense block.
+            Can be a positive integer or a list.
+            If positive integer, a set number of layers per dense block.
+            If list, nb_layer is used as provided. Note that list size must
+            be (nb_dense_block + 1)
+        upsampling_conv: number of convolutional layers in upsampling via subpixel convolution
+        upsampling_type: Can be one of 'upsampling', 'deconv', 'atrous' and
+            'subpixel'. Defines type of upsampling algorithm used.
+        batchsize: Fixed batch size. This is a temporary requirement for
+            computation of output shape in the case of Deconvolution2D layers.
+            Parameter will be removed in next iteration of Keras, which infers
+            output shape of deconvolution layers automatically.
+        input_shape: Only used for shape inference in fully convolutional networks.
+
+    Returns: keras tensor with nb_layers of __conv_block appended
+    '''
+
+    concat_axis = 1 if K.image_dim_ordering() == "th" else -1
+
+    if concat_axis == 1:  # th dim ordering
+        _, rows, cols = input_shape
+    else:
+        rows, cols, _ = input_shape
+
+    if reduction != 0.0:
+        assert reduction <= 1.0 and reduction > 0.0, "reduction value must lie between 0.0 and 1.0"
+
+    # check if upsampling_conv has minimum number of filters
+    # minimum is set to 12, as at least 3 color channels are needed for correct upsampling
+    assert upsampling_conv > 12 and upsampling_conv % 4 == 0, "Parameter `upsampling_conv` number of channels must " \
+                                                              "be a positive number divisible by 4 and greater " \
+                                                              "than 12"
+
+    # layers in each dense block
+    if type(nb_layers_per_block) is list or type(nb_layers_per_block) is tuple:
+        nb_layers = list(nb_layers_per_block)  # Convert tuple to list
+
+        assert len(nb_layers) == (nb_dense_block + 1), "If list, nb_layer is used as provided. " \
+                                                       "Note that list size must be (nb_dense_block + 1)"
+
+        final_nb_layer = nb_layers[-1]
+        nb_layers = nb_layers[:-1]
+
+    else:
+        final_nb_layer = nb_layers_per_block
+        nb_layers = [nb_layers_per_block] * nb_dense_block
+
+    if bottleneck:
+        nb_layers = [int(layer // 2) for layer in nb_layers]
+
+    # compute initial nb_filter if -1, else accept users initial nb_filter
+    if nb_filter <= 0:
+        nb_filter = 2 * growth_rate
+
+    # compute compression factor
+    compression = 1.0 - reduction
+
+    # Initial convolution
+    x = Convolution2D(48, 3, 3, init="he_uniform", border_mode="same", name="initial_conv2D", bias=False,
+                      W_regularizer=l2(weight_decay))(img_input)
+
+    skip_connection = x
+    skip_list = []
+
+    # Add dense blocks and transition down block
+    for block_idx in range(nb_dense_block):
+        x, nb_filter = __dense_block(x, nb_layers[block_idx], nb_filter, growth_rate, bottleneck=bottleneck,
+                                     dropout_rate=dropout_rate, weight_decay=weight_decay)
+
+        # Skip connection
+        x = merge([x, skip_connection], mode='concat', concat_axis=concat_axis)
+        skip_list.append(x)
+
+        # add transition_block
+        x = __transition_down_block(x, nb_filter, compression=compression, dropout_rate=dropout_rate,
+                                    weight_decay=weight_decay)
+        nb_filter = int(nb_filter * compression)  # this is calculated inside transition_down_block
+
+        # Preserve transition for next skip connection after dense
+        skip_connection = x
+
+    # The last dense_block does not have a transition_down_block
+    x, nb_filter = __dense_block(x, final_nb_layer, nb_filter, growth_rate, bottleneck=bottleneck,
+                                 dropout_rate=dropout_rate, weight_decay=weight_decay)
+
+    if K.image_dim_ordering() == 'th':
+        out_shape = [batchsize, nb_filter, rows // 16, cols // 16]
+    else:
+        out_shape = [batchsize, rows // 16, cols // 16, nb_filter]
+
+    # Add dense blocks and transition up block
+    for block_idx in range(nb_dense_block):
+        if K.image_dim_ordering() != 'th':
+            out_shape[3] = nb_filter
+
+        x = __transition_up_block(x, nb_filters=nb_filter, type=upsampling_type, output_shape=out_shape)
+
+        if K.image_dim_ordering() == 'th':
+            out_shape[2] *= 2
+            out_shape[3] *= 2
+        else:
+            out_shape[1] *= 2
+            out_shape[2] *= 2
+
+        x = merge([x, skip_list.pop()], mode='concat', concat_axis=concat_axis)
+
+        x, nb_filter = __dense_block(x, nb_layers[-block_idx], nb_filter, growth_rate, bottleneck=bottleneck,
+                                     dropout_rate=dropout_rate, weight_decay=weight_decay)
+
+    x = Convolution2D(nb_classes, 1, 1, activation='linear', border_mode='same', W_regularizer=l2(weight_decay),
+                      bias=False)(x)
+
+    if K.image_dim_ordering() == 'th':
+        channel, row, col = input_shape
+    else:
+        row, col, channel = input_shape
+
+    x = Reshape((row * col, nb_classes))(x)
+
+    x = Activation('softmax')(x)
+
+    x = Reshape((row, col, nb_classes))(x)
+
+    return x

--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -99,3 +99,9 @@ def extract_image_patches(X, ksizes, ssizes, border_mode="same", dim_ordering="t
     if dim_ordering == "tf":
         patches = KTF.permute_dimensions(patches, [0, 1, 2, 4, 5, 3])
     return patches
+
+
+def depth_to_space(input, scale, **kwargs):
+    ''' Uses phase shift algorithm to convert channels/depth for spacial resolution '''
+
+    return tf.depth_to_space(input, scale)

--- a/keras_contrib/backend/theano_backend.py
+++ b/keras_contrib/backend/theano_backend.py
@@ -25,6 +25,8 @@ from keras.backend.theano_backend import _preprocess_conv3d_filter_shape
 from keras.backend.theano_backend import _preprocess_border_mode
 from keras.backend.theano_backend import _postprocess_conv3d_output
 
+import itertools
+
 py_all = all
 
 
@@ -115,3 +117,18 @@ def extract_image_patches(X, ksizes, strides, border_mode="valid", dim_ordering=
     if dim_ordering == "tf":
         patches = KTH.permute_dimensions(patches, [0, 1, 2, 4, 5, 3])
     return patches
+
+
+def depth_to_space(input, scale):
+    ''' Uses phase shift algorithm to convert channels/depth for spacial resolution '''
+
+    b, k, row, col = input.shape
+    output_shape = (b, input._keras_shape[1] // (scale ** 2), row * scale, col * scale)
+
+    out = T.zeros(output_shape)
+    r = scale
+
+    for y, x in itertools.product(range(scale), repeat=2):
+        out = T.inc_subtensor(out[:, :, y::r, x::r], input[:, r * y + x:: r * r, :, :])
+
+    return out

--- a/keras_contrib/layers/convolutional.py
+++ b/keras_contrib/layers/convolutional.py
@@ -227,3 +227,31 @@ class Deconvolution3D(Convolution3D):
 Deconv3D = Deconvolution3D
 get_custom_objects().update({"Deconvolution3D": Deconvolution3D})
 get_custom_objects().update({"Deconv3D": Deconv3D})
+
+
+class SubPixelUpscaling(Layer):
+
+    def __init__(self, scale_factor=2, **kwargs):
+        super(SubPixelUpscaling, self).__init__(**kwargs)
+
+        self.scale_factor = scale_factor
+
+    def build(self, input_shape):
+        pass
+
+    def call(self, x, mask=None):
+        y = K.depth_to_space(x, self.scale_factor)
+        return y
+
+    def get_output_shape_for(self, input_shape):
+        if K.image_dim_ordering() == "th":
+            b, k, r, c = input_shape
+            return (b, k // (self.scale_factor ** 2), r * self.scale_factor, c * self.scale_factor)
+        else:
+            b, r, c, k = input_shape
+            return (b, r * self.scale_factor, c * self.scale_factor, k // (self.scale_factor ** 2))
+
+    def get_config(self):
+        config = {'scale_factor': self.scale_factor}
+        base_config = super(SubPixelUpscaling, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -39,6 +39,7 @@ class BatchRenormalization(Layer):
             of the data, for feature-wise normalization.
         r_max_value: Upper limit of the value of r_max.
         d_max_value: Upper limit of the value of d_max.
+        t_scale: Parameter to scale time steps.
         weights: Initialization weights.
             List of 2 Numpy arrays, with shapes:
             `[(input_shape,), (input_shape,)]`
@@ -69,7 +70,7 @@ class BatchRenormalization(Layer):
     """
 
     def __init__(self, epsilon=1e-3, mode=0, axis=-1, momentum=0.99,
-                 r_max_val=3., d_max_val=5., weights=None, beta_init='zero',
+                 r_max_val=3., d_max_val=5., t_scale=0.1, weights=None, beta_init='zero',
                  gamma_init='one', gamma_regularizer=None, beta_regularizer=None,
                  **kwargs):
         self.supports_masking = True
@@ -84,6 +85,7 @@ class BatchRenormalization(Layer):
         self.initial_weights = weights
         self.r_max_value = r_max_val
         self.d_max_value = d_max_val
+        self.t_delta = t_scale
         if self.mode == 0:
             self.uses_learning_phase = True
         super(BatchRenormalization, self).__init__(**kwargs)
@@ -166,7 +168,7 @@ class BatchRenormalization(Layer):
             t_val = K.get_value(self.t)
             r_val = self.r_max_value / (1 + (self.r_max_value - 1) * np.exp(-t_val))
             d_val = self.d_max_value / (1 + ((self.d_max_value / 1e-3) - 1) * np.exp(-(2 * t_val)))
-            t_val += 1.
+            t_val += float(self.t_delta)
 
             self.add_update([K.update(self.r_max, r_val),
                              K.update(self.d_max, d_val),

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -105,14 +105,7 @@ class BatchRenormalization(Layer):
                                            name='{}_running_std'.format(self.name),
                                            trainable=False)
 
-        # self.r_max = self.add_weight((1,), initializer='one',
-        #                              name='{}_r_max'.format(self.name),
-        #                              trainable=False)
         self.r_max = K.variable(np.ones((1,)), name='{}_r_max'.format(self.name))
-
-        # self.d_max = self.add_weight((1,), initializer='zero',
-        #                              name='{}_d_max'.format(self.name),
-        #                              trainable=False)
 
         self.d_max = K.variable(np.zeros((1,)), name='{}_d_max'.format(self.name))
 

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -210,6 +210,7 @@ class BatchRenormalization(Layer):
                   'beta_regularizer': self.beta_regularizer.get_config() if self.beta_regularizer else None,
                   'momentum': self.momentum,
                   'r_max_value': self.r_max_value,
-                  'd_max_value': self.d_max_value}
+                  'd_max_value': self.d_max_value,
+                  't_delta': self.t_delta}
         base_config = super(BatchRenormalization, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -150,10 +150,11 @@ class BatchRenormalization(Layer):
                 # now compute the re-normalized batch norm
                 x_normed = (x_normed * broadcast_r + broadcast_d) * broadcast_gamma + broadcast_beta
 
-            if self.mode == 0:
-                self.add_update([K.moving_average_update(self.running_mean, mean_batch, self.momentum),
-                                 K.moving_average_update(self.running_std, std_batch, self.momentum)], x)
+            # explicit update to moving mean and standard deviation
+            self.add_update([K.moving_average_update(self.running_mean, mean_batch, self.momentum),
+                             K.moving_average_update(self.running_std, std_batch, self.momentum)], x)
 
+            if self.mode == 0:
                 if sorted(reduction_axes) == range(K.ndim(x))[:-1]:
                     x_normed_running = K.batch_normalization(
                         x, self.running_mean, self.running_std,
@@ -188,6 +189,8 @@ class BatchRenormalization(Layer):
             #
             # x_normed = ((x_normed * r) + d) * self.gamma + self.beta
             raise ValueError('Batch Renormalization does not support mode=1')
+
+
         return x_normed
 
     def get_config(self):

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -138,11 +138,11 @@ class BatchRenormalization(Layer):
                 std_batch = K.sqrt(K.var(x, axis=reduction_axes) + self.epsilon)
 
             r_max_val = K.get_value(self.r_max)
-            r = std_batch / self.running_std
+            r = std_batch / (self.running_std + self.epsilon)
             r = K.stop_gradient(K.clip(r, 1 / r_max_val, r_max_val))
 
             d_max_val = K.get_value(self.d_max)
-            d = (mean_batch - self.running_mean) / self.running_mean
+            d = (mean_batch - self.running_mean) / (self.running_mean + self.epsilon)
             d = K.stop_gradient(K.clip(d, -d_max_val, d_max_val))
 
             if sorted(reduction_axes) == range(K.ndim(x))[:-1]:

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -1,3 +1,186 @@
 from keras.engine import Layer, InputSpec
 from .. import initializations, regularizers
 from .. import backend as K
+
+
+class BatchRenormalization(Layer):
+    """Batch renormalization layer (Sergey Ioffe, 2017).
+
+    Normalize the activations of the previous layer at each batch,
+    i.e. applies a transformation that maintains the mean activation
+    close to 0 and the activation standard deviation close to 1.
+
+    # Arguments
+        epsilon: small float > 0. Fuzz parameter.
+            Theano expects epsilon >= 1e-5.
+        mode: integer, 0, 1 or 2.
+            - 0: feature-wise normalization.
+                Each feature map in the input will
+                be normalized separately. The axis on which
+                to normalize is specified by the `axis` argument.
+                Note that if the input is a 4D image tensor
+                using Theano conventions (samples, channels, rows, cols)
+                then you should set `axis` to `1` to normalize along
+                the channels axis.
+                During training we use per-batch statistics to normalize
+                the data, and during testing we use running averages
+                computed during the training phase.
+            - 1: sample-wise normalization. This mode assumes a 2D input.
+            - 2: feature-wise normalization, like mode 0, but
+                using per-batch statistics to normalize the data during both
+                testing and training.
+        axis: integer, axis along which to normalize in mode 0. For instance,
+            if your input tensor has shape (samples, channels, rows, cols),
+            set axis to 1 to normalize per feature map (channels axis).
+        momentum: momentum in the computation of the
+            exponential average of the mean and standard deviation
+            of the data, for feature-wise normalization.
+        weights: Initialization weights.
+            List of 2 Numpy arrays, with shapes:
+            `[(input_shape,), (input_shape,)]`
+            Note that the order of this list is [gamma, beta, mean, std]
+        beta_init: name of initialization function for shift parameter
+            (see [initializations](../initializations.md)), or alternatively,
+            Theano/TensorFlow function to use for weights initialization.
+            This parameter is only relevant if you don't pass a `weights` argument.
+        gamma_init: name of initialization function for scale parameter (see
+            [initializations](../initializations.md)), or alternatively,
+            Theano/TensorFlow function to use for weights initialization.
+            This parameter is only relevant if you don't pass a `weights` argument.
+        gamma_regularizer: instance of [WeightRegularizer](../regularizers.md)
+            (eg. L1 or L2 regularization), applied to the gamma vector.
+        beta_regularizer: instance of [WeightRegularizer](../regularizers.md),
+            applied to the beta vector.
+
+    # Input shape
+        Arbitrary. Use the keyword argument `input_shape`
+        (tuple of integers, does not include the samples axis)
+        when using this layer as the first layer in a model.
+
+    # Output shape
+        Same shape as input.
+
+    # References
+        - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167)
+    """
+
+    def __init__(self, epsilon=1e-3, mode=0, axis=-1, momentum=0.99,
+                 weights=None, beta_init='zero', gamma_init='one',
+                 gamma_regularizer=None, beta_regularizer=None, **kwargs):
+        self.supports_masking = True
+        self.beta_init = initializations.get(beta_init)
+        self.gamma_init = initializations.get(gamma_init)
+        self.epsilon = epsilon
+        self.mode = mode
+        self.axis = axis
+        self.momentum = momentum
+        self.gamma_regularizer = regularizers.get(gamma_regularizer)
+        self.beta_regularizer = regularizers.get(beta_regularizer)
+        self.initial_weights = weights
+        self.r_max = 3.
+        self.d_max = 5.
+        if self.mode == 0:
+            self.uses_learning_phase = True
+        super(BatchRenormalization, self).__init__(**kwargs)
+
+    def build(self, input_shape):
+        self.input_spec = [InputSpec(shape=input_shape)]
+        shape = (input_shape[self.axis],)
+
+        self.gamma = self.add_weight(shape,
+                                     initializer=self.gamma_init,
+                                     regularizer=self.gamma_regularizer,
+                                     name='{}_gamma'.format(self.name))
+        self.beta = self.add_weight(shape,
+                                    initializer=self.beta_init,
+                                    regularizer=self.beta_regularizer,
+                                    name='{}_beta'.format(self.name))
+        self.running_mean = self.add_weight(shape, initializer='zero',
+                                            name='{}_running_mean'.format(self.name),
+                                            trainable=False)
+        self.running_std = self.add_weight(shape, initializer='one',
+                                           name='{}_running_std'.format(self.name),
+                                           trainable=False)
+
+        if self.initial_weights is not None:
+            self.set_weights(self.initial_weights)
+            del self.initial_weights
+        self.built = True
+
+    def call(self, x, mask=None):
+        if self.mode == 0 or self.mode == 2:
+            assert self.built, 'Layer must be built before being called'
+            input_shape = K.int_shape(x)
+
+            reduction_axes = list(range(len(input_shape)))
+            del reduction_axes[self.axis]
+            broadcast_shape = [1] * len(input_shape)
+            broadcast_shape[self.axis] = input_shape[self.axis]
+
+            if K.backend() == 'tf':
+                mean, var = K.KTF.nn.moments(x, reduction_axes, shift=None, name=None, keep_dims=False)
+                std = (K.sqrt(var + self.epsilon))
+            else:
+                mean = K.mean(x, axis=reduction_axes)
+                std = K.sqrt(K.var(x, axis=reduction_axes) + self.epsilon)
+
+            x_normed = (x - mean) / std
+
+            r = std / self.running_std
+            r = K.stop_gradient(K.clip(r, 1 / self.r_max, self.r_max))
+
+            d = (mean - self.running_mean) / std
+            d = K.stop_gradient(K.clip(d, -self.d_max, self.d_max))
+
+            # now compute the re-normalized batch norm
+            x_normed = ((x_normed * r) + d) * self.gamma + self.beta
+
+            if self.mode == 0:
+                self.add_update([K.moving_average_update(self.running_mean, mean, self.momentum),
+                                 K.moving_average_update(self.running_std, std, self.momentum)], x)
+
+                if sorted(reduction_axes) == range(K.ndim(x))[:-1]:
+                    x_normed_running = K.batch_normalization(
+                        x, self.running_mean, self.running_std,
+                        self.beta, self.gamma,
+                        epsilon=self.epsilon)
+                else:
+                    # need broadcasting
+                    broadcast_running_mean = K.reshape(self.running_mean, broadcast_shape)
+                    broadcast_running_std = K.reshape(self.running_std, broadcast_shape)
+                    broadcast_beta = K.reshape(self.beta, broadcast_shape)
+                    broadcast_gamma = K.reshape(self.gamma, broadcast_shape)
+                    x_normed_running = K.batch_normalization(
+                        x, broadcast_running_mean, broadcast_running_std,
+                        broadcast_beta, broadcast_gamma,
+                        epsilon=self.epsilon)
+
+                # pick the normalized form of x corresponding to the training phase
+                x_normed = K.in_train_phase(x_normed, x_normed_running)
+
+        elif self.mode == 1:
+            # sample-wise normalization
+            m = K.mean(x, axis=-1, keepdims=True)
+            std = K.sqrt(K.var(x, axis=-1, keepdims=True) + self.epsilon)
+            x_normed = (x - m) / (std + self.epsilon)
+
+            r = std / self.running_std
+            r = K.stop_gradient(K.clip(r, 1 / self.r_max, self.r_max))
+
+            d = (m - self.running_mean) / std
+            d = K.stop_gradient(K.clip(d, -self.d_max, self.d_max))
+
+            x_normed = ((x_normed * r) + d) * self.gamma + self.beta
+        return x_normed
+
+    def get_config(self):
+        config = {'epsilon': self.epsilon,
+                  'mode': self.mode,
+                  'axis': self.axis,
+                  'gamma_regularizer': self.gamma_regularizer.get_config() if self.gamma_regularizer else None,
+                  'beta_regularizer': self.beta_regularizer.get_config() if self.beta_regularizer else None,
+                  'momentum': self.momentum,
+                  'r_max': self.r_max,
+                  'd_max': self.d_max}
+        base_config = super(BatchRenormalization, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -228,8 +228,7 @@ class BatchRenormalization(Layer):
                   'gamma_regularizer': self.gamma_regularizer.get_config() if self.gamma_regularizer else None,
                   'beta_regularizer': self.beta_regularizer.get_config() if self.beta_regularizer else None,
                   'momentum': self.momentum,
-                  'r_max': self.r_max,
-                  'd_max': self.d_max,
-                  't': self.t}
+                  'r_max_value': self.r_max_value,
+                  'd_max_value': self.d_max_value}
         base_config = super(BatchRenormalization, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -85,7 +85,7 @@ class BatchRenormalization(Layer):
         self.r_max_value = r_max_val
         self.d_max_value = d_max_val
         self.t_delta = t_delta
-        if self.mode == 0:
+        if self.mode == 0 or self.mode == 2:
             self.uses_learning_phase = True
         super(BatchRenormalization, self).__init__(**kwargs)
 

--- a/keras_contrib/layers/normalization.py
+++ b/keras_contrib/layers/normalization.py
@@ -70,7 +70,7 @@ class BatchRenormalization(Layer):
     """
 
     def __init__(self, epsilon=1e-3, mode=0, axis=-1, momentum=0.99,
-                 r_max_val=3., d_max_val=5., t_delta=0.1, weights=None, beta_init='zero',
+                 r_max_val=3., d_max_val=5., t_delta=1., weights=None, beta_init='zero',
                  gamma_init='one', gamma_regularizer=None, beta_regularizer=None,
                  **kwargs):
         self.supports_masking = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,10 @@
 # Configuration of py.test
 [pytest]
 addopts=-v
-        #-n 2
+        -n 2
         --durations=10
-        #--cov-report term-missing
-        #--cov=keras
+        --cov-report term-missing
+        --cov=keras
 
 # Do not run tests in the build folder
 norecursedirs= build

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,10 @@
 # Configuration of py.test
 [pytest]
 addopts=-v
-        -n 2
+        #-n 2
         --durations=10
-        --cov-report term-missing
-        --cov=keras
+        #--cov-report term-missing
+        #--cov=keras
 
 # Do not run tests in the build folder
 norecursedirs= build

--- a/tests/keras_contrib/layers/test_normalization.py
+++ b/tests/keras_contrib/layers/test_normalization.py
@@ -9,6 +9,117 @@ from keras.models import Sequential, Model
 from keras import backend as K
 from keras_contrib import backend as KC
 
+input_1 = np.arange(10)
+input_2 = np.zeros(10)
+input_3 = np.ones((10))
+input_shapes = [np.ones((10, 10)), np.ones((10, 10, 10))]
+
+
+@keras_test
+def basic_batchrenorm_test():
+    from keras import regularizers
+    layer_test(normalization.BatchRenormalization,
+               kwargs={'mode': 1,
+                       'gamma_regularizer': regularizers.l2(0.01),
+                       'beta_regularizer': regularizers.l2(0.01)},
+               input_shape=(3, 4, 2))
+    layer_test(normalization.BatchRenormalization,
+               kwargs={'mode': 0},
+               input_shape=(3, 4, 2))
+
+
+@keras_test
+def test_batchrenorm_mode_0_or_2():
+    for mode in [0, 2]:
+        model = Sequential()
+        norm_m0 = normalization.BatchRenormalization(mode=mode, input_shape=(10,), momentum=0.8)
+        model.add(norm_m0)
+        model.compile(loss='mse', optimizer='sgd')
+
+        # centered on 5.0, variance 10.0
+        X = np.random.normal(loc=5.0, scale=10.0, size=(1000, 10))
+        model.fit(X, X, nb_epoch=4, verbose=0)
+        out = model.predict(X)
+        out -= K.eval(norm_m0.beta)
+        out /= K.eval(norm_m0.gamma)
+
+        assert_allclose(out.mean(), 0.0, atol=1e-1)
+        assert_allclose(out.std(), 1.0, atol=1e-1)
+
+
+@keras_test
+def test_batchrenorm_mode_0_or_2_twice():
+    # This is a regression test for issue #4881 with the old
+    # batch normalization functions in the Theano backend.
+    model = Sequential()
+    model.add(normalization.BatchRenormalization(mode=0, input_shape=(10, 5, 5), axis=1))
+    model.add(normalization.BatchRenormalization(mode=0, input_shape=(10, 5, 5), axis=1))
+    model.compile(loss='mse', optimizer='sgd')
+
+    X = np.random.normal(loc=5.0, scale=10.0, size=(20, 10, 5, 5))
+    model.fit(X, X, nb_epoch=1, verbose=0)
+    model.predict(X)
+
+
+@keras_test
+def test_batchnorm_mode_0_convnet():
+    model = Sequential()
+    norm_m0 = normalization.BatchRenormalization(mode=0, axis=1, input_shape=(3, 4, 4), momentum=0.8)
+    model.add(norm_m0)
+    model.compile(loss='mse', optimizer='sgd')
+
+    # centered on 5.0, variance 10.0
+    X = np.random.normal(loc=5.0, scale=10.0, size=(1000, 3, 4, 4))
+    model.fit(X, X, nb_epoch=4, verbose=0)
+    out = model.predict(X)
+    out -= np.reshape(K.eval(norm_m0.beta), (1, 3, 1, 1))
+    out /= np.reshape(K.eval(norm_m0.gamma), (1, 3, 1, 1))
+
+    assert_allclose(np.mean(out, axis=(0, 2, 3)), 0.0, atol=1e-1)
+    assert_allclose(np.std(out, axis=(0, 2, 3)), 1.0, atol=1e-1)
+
+
+@keras_test
+def test_batchnorm_mode_1():
+    norm_m1 = normalization.BatchRenormalization(input_shape=(10,), mode=1)
+    norm_m1.build(input_shape=(None, 10))
+
+    for inp in [input_1, input_2, input_3]:
+        out = (norm_m1.call(K.variable(inp)) - norm_m1.beta) / norm_m1.gamma
+        assert_allclose(K.eval(K.mean(out)), 0.0, atol=1e-1)
+        if inp.std() > 0.:
+            assert_allclose(K.eval(K.std(out)), 1.0, atol=1e-1)
+        else:
+            assert_allclose(K.eval(K.std(out)), 0.0, atol=1e-1)
+
+
+@keras_test
+def test_shared_batchnorm():
+    '''Test that a BN layer can be shared
+    across different data streams.
+    '''
+    # Test single layer reuse
+    bn = normalization.BatchRenormalization(input_shape=(10,), mode=0)
+    x1 = Input(shape=(10,))
+    bn(x1)
+
+    x2 = Input(shape=(10,))
+    y2 = bn(x2)
+
+    x = np.random.normal(loc=5.0, scale=10.0, size=(2, 10))
+    model = Model(x2, y2)
+    assert len(model.updates) == 5
+    model.compile('sgd', 'mse')
+    model.train_on_batch(x, x)
+
+    # Test model-level reuse
+    x3 = Input(shape=(10,))
+    y3 = model(x3)
+    new_model = Model(x3, y3)
+    assert len(model.updates) == 5
+    new_model.compile('sgd', 'mse')
+    new_model.train_on_batch(x, x)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras_contrib/layers/test_normalization.py
+++ b/tests/keras_contrib/layers/test_normalization.py
@@ -62,7 +62,7 @@ def test_batchrenorm_mode_0_or_2_twice():
 
 
 @keras_test
-def test_batchnorm_mode_0_convnet():
+def test_batchrenorm_mode_0_convnet():
     model = Sequential()
     norm_m0 = normalization.BatchRenormalization(mode=0, axis=1, input_shape=(3, 4, 4), momentum=0.8)
     model.add(norm_m0)
@@ -80,7 +80,7 @@ def test_batchnorm_mode_0_convnet():
 
 
 @keras_test
-def test_batchnorm_mode_1():
+def test_batchrenorm_mode_1():
     norm_m1 = normalization.BatchRenormalization(input_shape=(10,), mode=1)
     norm_m1.build(input_shape=(None, 10))
 
@@ -94,7 +94,7 @@ def test_batchnorm_mode_1():
 
 
 @keras_test
-def test_shared_batchnorm():
+def test_shared_batchrenorm():
     '''Test that a BN layer can be shared
     across different data streams.
     '''


### PR DESCRIPTION
Adds DenseNet FCN model builder script, depth_to_space operations in backend and SubpixelConvolutionUpsampling layer.

Todo:

1) See if we can test depth_to_space (I don't know how to do this. But I have tested the Subpixel convolutional layer which uses this, and output is correct. Does it imply that the operations in depth_to_space is correct as well?
2) See if we can somehow test SubpixelUsampling layer. The problem is it does not take in an input size, it simply receives the output of the previous layer and shuffles it to obtain a larger size in exchange for smaller number of kernels. Implementation should be correct, but tests need to be designed to work with an upsampling technique which is this unique. 