### PR TITLE
[Bugfix] Fix assertion error when using DenseNetFCN with grayscale input + Add activation parameter

### DIFF
--- a/keras_contrib/applications/densenet.py
+++ b/keras_contrib/applications/densenet.py
@@ -250,11 +250,26 @@ def DenseNetFCN(input_shape, nb_dense_block=5, growth_rate=16, nb_layers_per_blo
         upsampling_type = 'upsampling'
 
     # Determine proper input shape
-    input_shape = _obtain_input_shape(input_shape,
-                                      default_size=32,
-                                      min_size=16,
-                                      dim_ordering=K.image_dim_ordering(),
-                                      include_top=include_top)
+    min_size = 16
+
+    if K.image_dim_ordering() == 'th':
+        if input_shape is not None:
+            if ((input_shape[1] is not None and input_shape[1] < min_size) or
+                    (input_shape[2] is not None and input_shape[2] < min_size)):
+                raise ValueError('Input size must be at least ' +
+                                 str(min_size) + 'x' + str(min_size) + ', got '
+                                                                       '`input_shape=' + str(input_shape) + '`')
+        else:
+            input_shape = (classes, None, None)
+    else:
+        if input_shape is not None:
+            if ((input_shape[0] is not None and input_shape[0] < min_size) or
+                    (input_shape[1] is not None and input_shape[1] < min_size)):
+                raise ValueError('Input size must be at least ' +
+                                 str(min_size) + 'x' + str(min_size) + ', got '
+                                                                       '`input_shape=' + str(input_shape) + '`')
+        else:
+            input_shape = (None, None, classes)
 
     if input_tensor is None:
         img_input = Input(shape=input_shape)

--- a/keras_contrib/applications/densenet.py
+++ b/keras_contrib/applications/densenet.py
@@ -250,7 +250,7 @@ def DenseNetFCN(input_shape, nb_dense_block=5, growth_rate=16, nb_layers_per_blo
         upsampling_type = 'upsampling'
 
     # Determine proper input shape
-    min_size = 16
+    min_size = 2 ** nb_dense_block
 
     if K.image_dim_ordering() == 'th':
         if input_shape is not None:

--- a/tests/keras_contrib/layers/test_convolutional.py
+++ b/tests/keras_contrib/layers/test_convolutional.py
@@ -99,7 +99,6 @@ def test_cosineconvolution_2d():
                                    'data_format': data_format},
                            input_shape=(nbias_samples, nbias_row, nbias_col, stack_size))
 
-
                 layer_test(convolutional.CosineConvolution2D,
                            kwargs={'filters': nbias_filter,
                                    'kernel_size': (3, 3),
@@ -111,7 +110,6 @@ def test_cosineconvolution_2d():
                                    'bias_regularizer': 'l2',
                                    'activity_regularizer': 'l2'},
                            input_shape=(nbias_samples, nbias_row, nbias_col, stack_size))
-
 
     if data_format == 'channels_first':
         X = np.random.randn(1, 3, 5, 5)


### PR DESCRIPTION
Fixes a assertion error when gray scale image is input to DenseNetFCN. 

The submitted code is basically a copy of the _check_input code in Keras, with the removal of a few parts which cause the crash.