### PR TITLE
Fix keras argument spelling error in densenet.py

### DIFF
--- a/keras_contrib/applications/densenet.py
+++ b/keras_contrib/applications/densenet.py
@@ -328,7 +328,7 @@ def __conv_block(ip, nb_filter, bottleneck=False, dropout_rate=None, weight_deca
         x = Activation('relu')(x)
 
     x = Conv2D(nb_filter, (3, 3), kernel_initializer='he_uniform', padding='same', use_bias=False,
-               kenel_regularizer=l2(weight_decay))(x)
+               kernel_regularizer=l2(weight_decay))(x)
     if dropout_rate:
         x = Dropout(dropout_rate)(x)
 


### PR DESCRIPTION
It looks like in 1d57dd3c63eab5b181c412436c9fcffc748cc72e a spelling error ("kenel" not "kernal") was introduced into densenet.py that causes an argument error from keras when trying to use the network. This pull request corrects that.