### PR TITLE
Correct dense connectivity in DenseNet

### DIFF
--- a/keras_contrib/applications/densenet.py
+++ b/keras_contrib/applications/densenet.py
@@ -385,7 +385,7 @@ def __dense_block(x, nb_layers, nb_filter, growth_rate, bottleneck=False, dropou
         conv_block = __conv_block(x, growth_rate, bottleneck, dropout_rate, weight_decay)
         x_list.append(conv_block)
 
-        x = concatenate([x, conv_block], axis=concat_axis)
+        x = concatenate(x_list, axis=concat_axis)
 
         if grow_nb_filters:
             nb_filter += growth_rate


### PR DESCRIPTION
Due to an earlier commit, there was an incorrect update to the dense_block. 
It had no dense connectivity at all, even though it had the same number of parameters.

This patch fixes that.

Edit : Interestingly, the models are exactly equivalent (not in operation, but in performance). As in if you load either format of dense connectivity, the weights will load (if you use by_name=True) and the model will give exact same classification results. However, in the correct case, there is dense connectivity and the incorrect case it just looks like a resnet.