### PR TITLE
save_load_utils_test.py becomes tensorflow only to fix test failure

### DIFF
--- a/tests/keras_contrib/utils/save_load_utils_test.py
+++ b/tests/keras_contrib/utils/save_load_utils_test.py
@@ -4,10 +4,13 @@ from keras import backend as K
 from keras.layers import Input, Dense
 from keras.models import Model
 from numpy.testing import assert_allclose
+from keras.utils.test_utils import keras_test
 
 from keras_contrib.utils.save_load_utils import save_all_weights, load_all_weights
 
 
+@pytest.mark.skipif(K.backend() != 'tensorflow', reason='save_all_weights and load_all_weights only supported on TensorFlow')
+@keras_test
 def test_save_and_load_all_weights():
     '''
     Test save_all_weights and load_all_weights. Save and load optimizer and model weights but not configuration.


### PR DESCRIPTION
Making this test tensorflow only until https://github.com/farizrahman4u/keras-contrib/issues/157 is resolved.