### PR TITLE
tensorflow_backend.py add backend deleted in Keras

### DIFF
--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -183,6 +183,7 @@ def _postprocess_conv3d_output(x, data_format):
         x = tf.cast(x, 'float64')
     return x
 
+
 def conv2d(x, kernel, strides=(1, 1), padding='valid', data_format='channels_first',
            image_shape=None, filter_shape=None):
     '''2D convolution.

--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -8,13 +8,48 @@ except ImportError:
 from keras.backend import tensorflow_backend as KTF
 from keras.backend.common import floatx, image_data_format
 from keras.backend.tensorflow_backend import _preprocess_conv3d_input
-from keras.backend.tensorflow_backend import _postprocess_conv3d_output
 from keras.backend.tensorflow_backend import _preprocess_padding
 from keras.backend.tensorflow_backend import _preprocess_conv2d_input
-from keras.backend.tensorflow_backend import _postprocess_conv2d_output
 from keras.backend.tensorflow_backend import _to_tensor
 
 py_all = all
+
+
+def _postprocess_conv2d_output(x, data_format):
+    """Transpose and cast the output from conv2d if needed.
+
+    # Arguments
+        x: A tensor.
+        data_format: string, `"channels_last"` or `"channels_first"`.
+
+    # Returns
+        A tensor.
+    """
+
+    if data_format == 'channels_first':
+        x = tf.transpose(x, (0, 3, 1, 2))
+
+    if floatx() == 'float64':
+        x = tf.cast(x, 'float64')
+    return x
+
+
+ def _postprocess_conv3d_output(x, data_format):
+     """Transpose and cast the output from conv3d if needed.
+ 
+     # Arguments
+         x: A tensor.
+         data_format: string, `"channels_last"` or `"channels_first"`.
+ 
+     # Returns
+         A tensor.
+     """
+     if data_format == 'channels_first':
+         x = tf.transpose(x, (0, 4, 1, 2, 3))
+ 
+     if floatx() == 'float64':
+         x = tf.cast(x, 'float64')
+     return x
 
 
 def _preprocess_deconv_output_shape(x, shape, data_format):
@@ -27,7 +62,9 @@ def _preprocess_deconv_output_shape(x, shape, data_format):
     return shape
 
 
-def conv2d(x, kernel, strides=(1, 1), padding='valid', data_format='channels_first',
+def 
+
+(x, kernel, strides=(1, 1), padding='valid', data_format='channels_first',
            image_shape=None, filter_shape=None):
     '''2D convolution.
     # Arguments

--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -36,17 +36,17 @@ def _postprocess_conv2d_output(x, data_format):
 
  def _postprocess_conv3d_output(x, data_format):
      """Transpose and cast the output from conv3d if needed.
- 
+
      # Arguments
          x: A tensor.
          data_format: string, `"channels_last"` or `"channels_first"`.
- 
+
      # Returns
          A tensor.
      """
      if data_format == 'channels_first':
          x = tf.transpose(x, (0, 4, 1, 2, 3))
- 
+
      if floatx() == 'float64':
          x = tf.cast(x, 'float64')
      return x
@@ -62,9 +62,7 @@ def _preprocess_deconv_output_shape(x, shape, data_format):
     return shape
 
 
-def 
-
-(x, kernel, strides=(1, 1), padding='valid', data_format='channels_first',
+def conv2d(x, kernel, strides=(1, 1), padding='valid', data_format='channels_first',
            image_shape=None, filter_shape=None):
     '''2D convolution.
     # Arguments

--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -34,22 +34,22 @@ def _postprocess_conv2d_output(x, data_format):
     return x
 
 
- def _postprocess_conv3d_output(x, data_format):
-     """Transpose and cast the output from conv3d if needed.
+def _postprocess_conv3d_output(x, data_format):
+    """Transpose and cast the output from conv3d if needed.
 
-     # Arguments
-         x: A tensor.
-         data_format: string, `"channels_last"` or `"channels_first"`.
+    # Arguments
+        x: A tensor.
+        data_format: string, `"channels_last"` or `"channels_first"`.
 
-     # Returns
-         A tensor.
-     """
-     if data_format == 'channels_first':
-         x = tf.transpose(x, (0, 4, 1, 2, 3))
+    # Returns
+        A tensor.
+    """
+    if data_format == 'channels_first':
+        x = tf.transpose(x, (0, 4, 1, 2, 3))
 
-     if floatx() == 'float64':
-         x = tf.cast(x, 'float64')
-     return x
+    if floatx() == 'float64':
+        x = tf.cast(x, 'float64')
+    return x
 
 
 def _preprocess_deconv_output_shape(x, shape, data_format):

--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     import tensorflow.contrib.ctc as ctc
 from keras.backend import tensorflow_backend as KTF
+from keras.backend import dtype
 from keras.backend.common import floatx, image_data_format
 from keras.backend.tensorflow_backend import _to_tensor
 

--- a/keras_contrib/backend/tensorflow_backend.py
+++ b/keras_contrib/backend/tensorflow_backend.py
@@ -7,12 +7,144 @@ except ImportError:
     import tensorflow.contrib.ctc as ctc
 from keras.backend import tensorflow_backend as KTF
 from keras.backend.common import floatx, image_data_format
-from keras.backend.tensorflow_backend import _preprocess_conv3d_input
-from keras.backend.tensorflow_backend import _preprocess_padding
-from keras.backend.tensorflow_backend import _preprocess_conv2d_input
 from keras.backend.tensorflow_backend import _to_tensor
 
 py_all = all
+
+
+# CONVOLUTIONS
+
+def _preprocess_deconv3d_output_shape(x, shape, data_format):
+    """Get the output_shape for the 3D deconvolution.
+
+    # Arguments
+        x: input tensor.
+        shape: output shape.
+        data_format: string, `"channels_last"` or `"channels_first"`.
+
+    # Returns
+        The output shape.
+    """
+    if data_format == 'channels_first':
+        shape = (shape[0], shape[2], shape[3], shape[4], shape[1])
+
+    if shape[0] is None:
+        shape = (tf.shape(x)[0], ) + tuple(shape[1:])
+        shape = tf.stack(list(shape))
+    return shape
+
+
+def _preprocess_deconv_output_shape(x, shape, data_format):
+    """Get the output_shape for the deconvolution.
+
+    # Arguments
+        x: input tensor.
+        shape: output shape.
+        data_format: string, `"channels_last"` or `"channels_first"`.
+
+    # Returns
+        The output shape.
+    """
+    if data_format == 'channels_first':
+        shape = (shape[0], shape[2], shape[3], shape[1])
+
+    if shape[0] is None:
+        shape = (tf.shape(x)[0], ) + tuple(shape[1:])
+        shape = tf.stack(list(shape))
+    return shape
+
+
+def _preprocess_conv2d_input(x, data_format):
+    """Transpose and cast the input before the conv2d.
+
+    # Arguments
+        x: input tensor.
+        data_format: string, `"channels_last"` or `"channels_first"`.
+
+    # Returns
+        A tensor.
+    """
+    if dtype(x) == 'float64':
+        x = tf.cast(x, 'float32')
+    if data_format == 'channels_first':
+        # TF uses the last dimension as channel dimension,
+        # instead of the 2nd one.
+        # TH input shape: (samples, input_depth, rows, cols)
+        # TF input shape: (samples, rows, cols, input_depth)
+        x = tf.transpose(x, (0, 2, 3, 1))
+    return x
+
+
+def _preprocess_conv3d_input(x, data_format):
+    """Transpose and cast the input before the conv3d.
+
+    # Arguments
+        x: input tensor.
+        data_format: string, `"channels_last"` or `"channels_first"`.
+
+    # Returns
+        A tensor.
+    """
+    if dtype(x) == 'float64':
+        x = tf.cast(x, 'float32')
+    if data_format == 'channels_first':
+        x = tf.transpose(x, (0, 2, 3, 4, 1))
+    return x
+
+
+def _preprocess_conv2d_kernel(kernel, data_format):
+    """Transpose and cast the kernel before the conv2d.
+
+    # Arguments
+        kernel: kernel tensor.
+        data_format: string, `"channels_last"` or `"channels_first"`.
+
+    # Returns
+        A tensor.
+    """
+    if dtype(kernel) == 'float64':
+        kernel = tf.cast(kernel, 'float32')
+    if data_format == 'channels_first':
+        kernel = tf.transpose(kernel, (2, 3, 1, 0))
+    return kernel
+
+
+def _preprocess_conv3d_kernel(kernel, data_format):
+    """Transpose and cast the kernel before the conv3d.
+
+    # Arguments
+        kernel: kernel tensor.
+        data_format: string, `"channels_last"` or `"channels_first"`.
+
+    # Returns
+        A tensor.
+    """
+    if dtype(kernel) == 'float64':
+        kernel = tf.cast(kernel, 'float32')
+    if data_format == 'channels_first':
+        kernel = tf.transpose(kernel, (2, 3, 4, 1, 0))
+    return kernel
+
+
+def _preprocess_padding(padding):
+    """Convert keras' padding to tensorflow's padding.
+
+    # Arguments
+        padding: string, `"same"` or `"valid"`.
+
+    # Returns
+        a string, `"SAME"` or `"VALID"`.
+
+    # Raises
+        ValueError: if `padding` is invalid.
+    """
+    if padding == 'same':
+        padding = 'SAME'
+    elif padding == 'valid':
+        padding = 'VALID'
+    else:
+        raise ValueError('Invalid padding:', padding)
+    return padding
 
 
 def _postprocess_conv2d_output(x, data_format):
@@ -50,17 +182,6 @@ def _postprocess_conv3d_output(x, data_format):
     if floatx() == 'float64':
         x = tf.cast(x, 'float64')
     return x
-
-
-def _preprocess_deconv_output_shape(x, shape, data_format):
-    if data_format == 'channels_first':
-        shape = (shape[0],) + tuple(shape[2:]) + (shape[1],)
-
-    if shape[0] is None:
-        shape = (tf.shape(x)[0],) + tuple(shape[1:])
-        shape = tf.stack(list(shape))
-    return shape
-
 
 def conv2d(x, kernel, strides=(1, 1), padding='valid', data_format='channels_first',
            image_shape=None, filter_shape=None):


### PR DESCRIPTION
I'm creating a workaround for keras_backend change by directly incorporating the relevant backend code from [keras/backend/tensorflow_backend.py](https://github.com/fchollet/keras/blob/cc3328a7039ba126e1eee6feda8c075e553be133/keras/backend/tensorflow_backend.py) into keras_contrib. 
The unit test failures are caused by changes form https://github.com/fchollet/keras/commit/6b106ab4ec9a1c0eb3e24ae590ce63f84022ad40.

Long term this needs to be fixed properly to match and use the functions in the keras/master tensorflow backend.