### PR TITLE
Add Weights for NASNet models

### DIFF
--- a/keras_contrib/applications/nasnet.py
+++ b/keras_contrib/applications/nasnet.py
@@ -186,7 +186,7 @@ def NASNet(input_shape=None,
             img_input = input_tensor
 
     assert penultimate_filters % 24 == 0, "`penultimate_filters` needs to be divisible " \
-                                          "by 6 * (2^N)."
+                                          "by 24."
 
     channel_dim = 1 if K.image_data_format() == 'channels_first' else -1
     filters = penultimate_filters // 24

--- a/keras_contrib/applications/nasnet.py
+++ b/keras_contrib/applications/nasnet.py
@@ -163,7 +163,7 @@ def NASNet(input_shape=None,
                                       require_flatten=include_top or weights)
 
     if K.image_data_format() != 'channels_last':
-        warnings.warn('The MobileNet family of models is only available '
+        warnings.warn('The NASNet family of models is only available '
                       'for the input data format "channels_last" '
                       '(width, height, channels). '
                       'However your settings specify the default '

--- a/keras_contrib/applications/nasnet.py
+++ b/keras_contrib/applications/nasnet.py
@@ -10,6 +10,8 @@ The reference implementation:
    nasnet/nasnet.py
 2. TensorNets
  - https://github.com/taehoonlee/tensornets/blob/master/tensornets/nasnets.py
+3. Weights
+ - https://github.com/tensorflow/models/tree/master/research/slim/nets/nasnet
 """
 from __future__ import print_function
 from __future__ import absolute_import


### PR DESCRIPTION
Contains changes to support weight files for NASNet Large and NASNet Mobile

Changes

- Small but important changes to the normal and reduction cells to make them correct
- Support for weight loading for 224 and 331 size inputs when built using the pre-built models